### PR TITLE
Use pkeyutl instead of deprecated rsautl

### DIFF
--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -144,7 +144,7 @@ function set_cryptic_privileged() {
         readarray -d';' -t ADHOC_PAIR <<<"${!LONG_ADHOC_NAME}"
 
         # Take the key, decrypt it with our RSA private key
-        base64dec <<<"${ADHOC_PAIR[0]}" | openssl rsautl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"
+        base64dec <<<"${ADHOC_PAIR[0]}" | openssl pkeyutl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"
 
         # Make sure the AES key is the right length
         if [[ $(wc -c <"${TEMP_KEYFILE}") != "128" ]]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -128,11 +128,11 @@ function randbase64() {
 
 # Encrypt something using RSA with the RSA public key as the first argument
 function encrypt_rsa() {
-    openssl rsautl -encrypt -pubin -inkey "${1}"
+    openssl pkeyutl -encrypt -pubin -inkey "${1}"
 }
 # Decrypt something using RSA with the RSA private key as the first argument
 function decrypt_rsa() {
-    openssl rsautl -decrypt -inkey "${1}"
+    openssl pkeyutl -decrypt -inkey "${1}"
 }
 
 # Sign something using RSA with the RSA key as the first argument


### PR DESCRIPTION
openssl-rsautl was deprecated in favor of openssl-pkeyutl in version 3.0 (which is the documented minimum version for cryptic already). Fixes #24.