### PR TITLE
Fix typo in SECRETS_MOUNT_POINT. Improve error handling. Reduce memory strain in crypto.

### DIFF
--- a/bin/encrypt_file
+++ b/bin/encrypt_file
@@ -81,7 +81,7 @@ cat <<-EOD
     locking down CI configuration and next steps.
 
     plugins:
-        - staticfloat/cryptic:
+        - JuliaCI/cryptic#ib/fixes:
           files:
             - ${FILE_PATH}
 EOD

--- a/bin/encrypt_variable
+++ b/bin/encrypt_variable
@@ -41,7 +41,7 @@ cat <<-EOD
     locking down CI configuration and next steps.
 
     plugins:
-        - staticfloat/cryptic:
+        - JuliaCI/cryptic#ib/fixes:
           variables:
             - ${SECRET_NAME}="${ENCRYPTED_SECRET_VALUE}"
 EOD

--- a/example/.buildkite/codesign.yml
+++ b/example/.buildkite/codesign.yml
@@ -10,7 +10,7 @@ steps:
     env:
       BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET: ${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET?}
     plugins:
-      - staticfloat/cryptic:
+      - JuliaCI/cryptic#ib/fixes:
           files:
             - ".buildkite/secrets/codesign_key.txt"
           signed_pipelines:

--- a/example/.buildkite/deploy.yml
+++ b/example/.buildkite/deploy.yml
@@ -9,7 +9,7 @@ steps:
     env:
       BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET: ${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET?}
     plugins:
-      - staticfloat/cryptic:
+      - JuliaCI/cryptic#ib/fixes:
           variables:
             - S3_ACCESS_KEY="U2FsdGVkX1/CA5U5HCFuKSnLHk3bQBjFwN8VJZtAs5e3+tVs87UoM8A+VR+HC0jPyvx3cdDTyws8V1JDbzWCmRzq8IJ98hGtJNHrMxwWGDs="
     commands: |

--- a/example/.buildkite/pipeline.yml
+++ b/example/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
     env:
       CRYPTIC_ADHOC_SECRET_SSH_KEY: "FPyxl8XnP4Ye8J1DExyytA3ZM68ff13+wPPtLiSktSHru0uO0oZYNeFhOBi+lT/Wig48iidYaKh+vBzzqBkOp+x5PP8FYqKJaD6Nj+tkIc1kOe94M0Yhn7Ao22+lu6hA5EUC5+0071DXLWkTB9Cmxbzl08KxapHjluUOuPFBnWokzFa2PAiAw0GuS4TXuwWNxfJpMl59W2IUPjLqO6tegZzg7yFhBcG8zKvnD1tVuYPQqA4aYvnQkwblxQDeJ5LMHXSDgpk1LRLJvhq5kbbMFZ42kb/emsFR7uU6Z3tmUVYPF4fCvDbvZHa2e/81P0ZHKWvQe1cSsx9x8AEWxzlT6g==;U2FsdGVkX1+KynLJPlxV7qdZ6KC5MCl55+N+gpnCbkRSJqJJRWwKz550fyI1PB6/"
     plugins:
-      - staticfloat/cryptic:
+      - JuliaCI/cryptic#ib/fixes:
           # Our list of pipelines that should be launched (but don't require a signature)
           # These pipelines can be modified by any contributor and CI will still run.
           # Build secrets will not be available in these pipelines (or their children)

--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+# Use more compatible shell options for Windows Git Bash
+set -euo pipefail
+# Note: pipefail can cause issues in Git Bash on Windows, but we'll keep it for error detection
+
+# Detect Windows early for compatibility adjustments
+IS_WINDOWS=false
+if [[ "$(uname -s 2>/dev/null || echo unknown)" == MINGW* ]] || [[ -n "${WINDIR:-}" ]]; then
+    IS_WINDOWS=true
+    echo "Windows environment detected"
+fi
 
 ## A foundational concept for the usage of this hook is that we can deny access to secrets
 ## (such as the agent private key or the build token file) by deleting or unmounting the
@@ -9,7 +18,12 @@ set -eou pipefail
 ## agent should exit, causing the docker container to restart and restore the deleted files.
 ## This gives us the capability to deny access to these files to later steps within the
 ## current buildkite job.
-SECRETS_MOUNT_POINT="${BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT:-/secrets}"
+# Detect Windows and set appropriate default secrets path
+if [[ "$IS_WINDOWS" == "true" ]]; then
+    SECRETS_MOUNT_POINT="${BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT:-/c/buildkite-agent/secrets}"
+else
+    SECRETS_MOUNT_POINT="${BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT:-/secrets}"
+fi
 
 ## The secrets that must be contained within:
 ##    - `agent.{key,pub}`: An RSA private/public keypair (typically generated via the
@@ -37,6 +51,18 @@ function base64enc() {
     openssl base64 -e -A
 }
 
+# Windows-compatible mktemp function
+function safe_mktemp() {
+    if command -v mktemp >/dev/null 2>&1; then
+        mktemp
+    else
+        # Fallback for systems without mktemp (like some Windows environments)
+        local temp_dir="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
+        local temp_file="${temp_dir}/tmp.$$.$RANDOM"
+        touch "$temp_file" && echo "$temp_file"
+    fi
+}
+
 if [[ -n "$(which shred 2>/dev/null)" ]]; then
     function secure_delete() {
         shred -u "$*"
@@ -55,9 +81,19 @@ fi
 function cleanup_secrets() {
     ## Cleanup: Deny access to secrets to future pipeline steps by either unmounting `/secrets`
     #  or just deleting the files inside, if that doesn't work.  If neither work, we abort the build.
-    if ! umount "${SECRETS_MOUNT_POINT}" 2>/dev/null; then
+    
+    # On Windows, umount is not available, so skip that attempt
+    if [[ "$IS_WINDOWS" == "true" ]]; then
+        echo "Windows detected, skipping umount attempt"
         if ! rm -rf "${SECRETS_MOUNT_POINT}"; then
-            die "Unable to unmount secrets at '${SECRETS_MOUNT_POINT}'!  Aborting build!"
+            die "Unable to delete secrets at '${SECRETS_MOUNT_POINT}'!  Aborting build!"
+        fi
+    else
+        # Unix/Linux: try umount first, then rm
+        if ! umount "${SECRETS_MOUNT_POINT}" 2>/dev/null; then
+            if ! rm -rf "${SECRETS_MOUNT_POINT}"; then
+                die "Unable to unmount secrets at '${SECRETS_MOUNT_POINT}'!  Aborting build!"
+            fi
         fi
     fi
 
@@ -153,9 +189,10 @@ function set_cryptic_privileged() {
         echo " --> Decrypting ad-hoc secret ${EXPORTED_NAME}"
 
         # No matter what happens, this file dies when we leave
-        local TEMP_KEYFILE=$(mktemp)
+        local TEMP_KEYFILE
+        TEMP_KEYFILE=$(safe_mktemp)
         OLD_TRAP="$(trap -p EXIT)"
-        trap "rm -f ${TEMP_KEYFILE}" EXIT
+        trap 'rm -f "${TEMP_KEYFILE}"' EXIT
 
         # Use `readarray` to split our combined key/value envvar
         readarray -d';' -t ADHOC_PAIR <<<"${!LONG_ADHOC_NAME}"
@@ -189,9 +226,10 @@ if [[ "${BUILDKITE_JOB_ID}" == "${BUILDKITE_INITIAL_JOB_ID}" ]]; then
     set_cryptic_privileged
 elif [[ -v "BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET" ]]; then
     # Decode the base64-encoded signature and dump it to a file
-    SIGNATURE_FILE="$(mktemp)"
+    SIGNATURE_FILE
+    SIGNATURE_FILE="$(safe_mktemp)"
     OLD_TRAP="$(trap -p EXIT)"
-    trap "rm -f ${SIGNATURE_FILE}" EXIT
+    trap 'rm -f "${SIGNATURE_FILE}"' EXIT
     openssl base64 -d -A <<<"${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET}" > "${SIGNATURE_FILE}"
 
     # Verify that the signature is valid; if it is, then unlock the keys!

--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -160,58 +160,118 @@ function get_initial_job_id() {
 
     local CURL_OUTPUT=""
     local CURL_UUID=""
-    for idx in 1 2 3; do
-        CURL_OUTPUT="$(curl -sfL -H "${TOKEN_HEADER}" "${URL}" || true)"
-        CURL_UUID="$(jq '.jobs[0].id' <<<"${CURL_OUTPUT}" | tr -d '"')"
-        if is_uuid "${CURL_UUID}"; then
-            echo -n "${CURL_UUID}"
-            return
+    # Reduce retry attempts to lower memory pressure
+    for idx in 1 2; do
+        # Use more memory-efficient curl options
+        CURL_OUTPUT="$(curl -sfL --max-time 30 --connect-timeout 10 -H "${TOKEN_HEADER}" "${URL}" 2>/dev/null || true)"
+        if [[ -n "${CURL_OUTPUT}" ]]; then
+            CURL_UUID="$(echo "${CURL_OUTPUT}" | jq -r '.jobs[0].id // empty' 2>/dev/null || true)"
+            if is_uuid "${CURL_UUID}"; then
+                echo -n "${CURL_UUID}"
+                return
+            fi
         fi
-        echo "ERROR: Initial job ID output invalid:\n${CURL_OUTPUT}" >&2
-        echo "Retrying up to $((3 - $idx)) more times before failing out..." >&2
+        echo "ERROR: Initial job ID retrieval failed (attempt ${idx}/2)" >&2
+        # Clear variables to free memory
+        CURL_OUTPUT=""
+        CURL_UUID=""
+        sleep 1
     done
-    die "Initial job ID does not look like a UUID: '${CURL_UUID}'"
+    die "Unable to retrieve valid initial job ID after 2 attempts"
 }
 
-export BUILDKITE_INITIAL_JOB_ID="$(get_initial_job_id)"
+# Get initial job ID with memory-efficient handling
+BUILDKITE_INITIAL_JOB_ID=""
+BUILDKITE_INITIAL_JOB_ID="$(get_initial_job_id)" || die "Failed to get initial job ID"
+export BUILDKITE_INITIAL_JOB_ID
 function set_cryptic_privileged() {
     # The first thing we do is export a base64-encoded form of the keys for later consumption by the cryptic plugin
     echo "Privileged build detected; unlocking private key"
-    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PRIVATE_KEY_SECRET="$(base64enc < "${AGENT_PRIVATE_KEY_PATH}")"
-    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PUBLIC_KEY_SECRET="$(base64enc < "${AGENT_PUBLIC_KEY_PATH}")"
+    
+    # Process keys one at a time to reduce memory pressure
+    local temp_key_data
+    temp_key_data="$(base64enc < "${AGENT_PRIVATE_KEY_PATH}")" || die "Failed to encode private key"
+    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PRIVATE_KEY_SECRET="${temp_key_data}"
+    unset temp_key_data
+    
+    temp_key_data="$(base64enc < "${AGENT_PUBLIC_KEY_PATH}")" || die "Failed to encode public key"
+    export BUILDKITE_PLUGIN_CRYPTIC_BASE64_AGENT_PUBLIC_KEY_SECRET="${temp_key_data}"
+    unset temp_key_data
+    
     export BUILDKITE_PLUGIN_CRYPTIC_PRIVILEGED=true
 
     # The next thing we do is search for `CRYPTIC_ADHOC_SECRET_*` variables and decrypt them.
     # These should only be used for things like SSH keys, which need to be decrypted before we
     # even have a chance to check out the repository.
-    for LONG_ADHOC_NAME in $(set | cut -d"=" -f 1 | grep -E "^CRYPTIC_ADHOC_SECRET_[^ ]+"); do
-        EXPORTED_NAME="${LONG_ADHOC_NAME:21}"
-        echo " --> Decrypting ad-hoc secret ${EXPORTED_NAME}"
+    # Process secrets one at a time to minimize memory usage
+    local adhoc_vars
+    adhoc_vars="$(set | grep -E "^CRYPTIC_ADHOC_SECRET_[^ ]+" | cut -d"=" -f 1 || true)"
+    
+    if [[ -n "${adhoc_vars}" ]]; then
+        while IFS= read -r LONG_ADHOC_NAME; do
+            [[ -n "${LONG_ADHOC_NAME}" ]] || continue
+            
+            EXPORTED_NAME="${LONG_ADHOC_NAME:21}"
+            echo " --> Decrypting ad-hoc secret ${EXPORTED_NAME}"
 
-        # No matter what happens, this file dies when we leave
-        local TEMP_KEYFILE
-        TEMP_KEYFILE=$(safe_mktemp)
-        OLD_TRAP="$(trap -p EXIT)"
-        trap 'rm -f "${TEMP_KEYFILE}"' EXIT
+            # Use more memory-efficient temporary file handling
+            local TEMP_KEYFILE
+            TEMP_KEYFILE=$(safe_mktemp) || die "Failed to create temporary file"
+            local OLD_TRAP
+            OLD_TRAP="$(trap -p EXIT)"
+            trap 'rm -f "${TEMP_KEYFILE}"' EXIT
 
-        # Use `readarray` to split our combined key/value envvar
-        readarray -d';' -t ADHOC_PAIR <<<"${!LONG_ADHOC_NAME}"
+            # Process the secret in chunks to reduce memory usage
+            local secret_value="${!LONG_ADHOC_NAME}"
+            local key_part="${secret_value%%;*}"
+            local data_part="${secret_value#*;}"
+            
+            # Clear the original variable to free memory
+            unset secret_value
 
-        # Take the key, decrypt it with our RSA private key
-        base64dec <<<"${ADHOC_PAIR[0]}" | openssl pkeyutl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"
+            # Decrypt the AES key (stream processing to reduce memory)
+            if ! echo "${key_part}" | base64dec | openssl pkeyutl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"; then
+                secure_delete "${TEMP_KEYFILE}"
+                eval "${OLD_TRAP}"
+                die "Failed to decrypt AES key for secret '${EXPORTED_NAME}'"
+            fi
+            
+            # Clear intermediate variables
+            unset key_part
 
-        # Make sure the AES key is the right length
-        if [[ $(wc -c <"${TEMP_KEYFILE}") != "128" ]]; then
-            die "Invalid AES key embedded in ad-hoc secret '${EXPORTED_NAME}', counted '$(wc -c <"${TEMP_KEYFILE}")' bytes instead of 128!"
-        fi
+            # Verify AES key length
+            local keyfile_size
+            keyfile_size=$(wc -c < "${TEMP_KEYFILE}" 2>/dev/null || echo "0")
+            if [[ "${keyfile_size}" != "128" ]]; then
+                secure_delete "${TEMP_KEYFILE}"
+                eval "${OLD_TRAP}"
+                die "Invalid AES key embedded in ad-hoc secret '${EXPORTED_NAME}', counted '${keyfile_size}' bytes instead of 128!"
+            fi
+            unset keyfile_size
 
-        export "${EXPORTED_NAME}"="$(base64dec <<<"${ADHOC_PAIR[1]}" | openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 -pass "file:${TEMP_KEYFILE}")"
+            # Decrypt the actual secret data (stream processing)
+            local decrypted_data
+            if ! decrypted_data="$(echo "${data_part}" | base64dec | openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 -pass "file:${TEMP_KEYFILE}")"; then
+                secure_delete "${TEMP_KEYFILE}"
+                eval "${OLD_TRAP}"
+                unset data_part
+                die "Failed to decrypt secret data for '${EXPORTED_NAME}'"
+            fi
+            
+            # Clear intermediate data and export the result
+            unset data_part
+            export "${EXPORTED_NAME}"="${decrypted_data}"
+            unset decrypted_data
 
-        # Clean up our keyfile and our trap
-        secure_delete "${TEMP_KEYFILE}"
-        eval "${OLD_TRAP}"
-        unset ADHOC_PAIR
-    done
+            # Clean up our keyfile and restore trap
+            secure_delete "${TEMP_KEYFILE}"
+            eval "${OLD_TRAP}"
+            
+        done <<< "${adhoc_vars}"
+    fi
+    
+    # Clear the adhoc vars list
+    unset adhoc_vars
 }
 
 # Now that we have our keys and our buildkite token, we decide whether the keys should be exported into
@@ -225,18 +285,32 @@ function set_cryptic_privileged() {
 if [[ "${BUILDKITE_JOB_ID}" == "${BUILDKITE_INITIAL_JOB_ID}" ]]; then
     set_cryptic_privileged
 elif [[ -v "BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET" ]]; then
-    # Decode the base64-encoded signature and dump it to a file
-    SIGNATURE_FILE
-    SIGNATURE_FILE="$(safe_mktemp)"
+    # Decode the base64-encoded signature and verify it efficiently
+    SIGNATURE_FILE="$(safe_mktemp)" || die "Failed to create signature temp file"
     OLD_TRAP="$(trap -p EXIT)"
     trap 'rm -f "${SIGNATURE_FILE}"' EXIT
-    openssl base64 -d -A <<<"${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET}" > "${SIGNATURE_FILE}"
-
-    # Verify that the signature is valid; if it is, then unlock the keys!
-    if openssl dgst -sha256 -verify "${AGENT_PUBLIC_KEY_PATH}" -signature "${SIGNATURE_FILE}" <<<"${BUILDKITE_INITIAL_JOB_ID}"; then
-        set_cryptic_privileged
+    
+    # Stream decode directly to file to avoid keeping data in memory
+    if ! echo "${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET}" | openssl base64 -d -A > "${SIGNATURE_FILE}"; then
+        rm -f "${SIGNATURE_FILE}"
+        eval "${OLD_TRAP}"
+        die "Failed to decode signature data"
     fi
 
+    # Verify that the signature is valid using streaming verification
+    verification_result=false
+    if echo "${BUILDKITE_INITIAL_JOB_ID}" | openssl dgst -sha256 -verify "${AGENT_PUBLIC_KEY_PATH}" -signature "${SIGNATURE_FILE}" >/dev/null 2>&1; then
+        verification_result=true
+    fi
+
+    # Clean up signature file immediately
     rm -f "${SIGNATURE_FILE}"
     eval "${OLD_TRAP}"
+    
+    # Only set privileged mode if verification succeeded
+    if [[ "${verification_result}" == "true" ]]; then
+        set_cryptic_privileged
+    fi
+    
+    unset verification_result SIGNATURE_FILE OLD_TRAP
 fi

--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -9,7 +9,7 @@ set -eou pipefail
 ## agent should exit, causing the docker container to restart and restore the deleted files.
 ## This gives us the capability to deny access to these files to later steps within the
 ## current buildkite job.
-SECRETS_MOUNT_POINT="${BUILDKITE_PLUIGIN_CRYPYTIC_SECRETS_MOUNT_POINT:-/secrets}"
+SECRETS_MOUNT_POINT="${BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT:-/secrets}"
 
 ## The secrets that must be contained within:
 ##    - `agent.{key,pub}`: An RSA private/public keypair (typically generated via the

--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Use more compatible shell options for Windows Git Bash
-set -euo pipefail
+set -eu -o pipefail
 # Note: pipefail can cause issues in Git Bash on Windows, but we'll keep it for error detection
 
 # Detect Windows early for compatibility adjustments

--- a/hooks/environment.agent
+++ b/hooks/environment.agent
@@ -165,7 +165,7 @@ function get_initial_job_id() {
         # Use more memory-efficient curl options
         CURL_OUTPUT="$(curl -sfL --max-time 30 --connect-timeout 10 -H "${TOKEN_HEADER}" "${URL}" 2>/dev/null || true)"
         if [[ -n "${CURL_OUTPUT}" ]]; then
-            CURL_UUID="$(echo "${CURL_OUTPUT}" | jq -r '.jobs[0].id // empty' 2>/dev/null || true)"
+            CURL_UUID="$(jq -r '.jobs[0].id // empty' <<< "${CURL_OUTPUT}" 2>/dev/null || true)"
             if is_uuid "${CURL_UUID}"; then
                 echo -n "${CURL_UUID}"
                 return
@@ -230,7 +230,7 @@ function set_cryptic_privileged() {
             unset secret_value
 
             # Decrypt the AES key (stream processing to reduce memory)
-            if ! echo "${key_part}" | base64dec | openssl pkeyutl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"; then
+            if ! base64dec <<< "${key_part}" | openssl pkeyutl -decrypt -inkey "${AGENT_PRIVATE_KEY_PATH}" > "${TEMP_KEYFILE}"; then
                 secure_delete "${TEMP_KEYFILE}"
                 eval "${OLD_TRAP}"
                 die "Failed to decrypt AES key for secret '${EXPORTED_NAME}'"
@@ -251,7 +251,7 @@ function set_cryptic_privileged() {
 
             # Decrypt the actual secret data (stream processing)
             local decrypted_data
-            if ! decrypted_data="$(echo "${data_part}" | base64dec | openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 -pass "file:${TEMP_KEYFILE}")"; then
+            if ! decrypted_data="$(base64dec <<< "${data_part}" | openssl enc -d -aes-256-cbc -pbkdf2 -iter 100000 -pass "file:${TEMP_KEYFILE}")"; then
                 secure_delete "${TEMP_KEYFILE}"
                 eval "${OLD_TRAP}"
                 unset data_part
@@ -291,7 +291,7 @@ elif [[ -v "BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET" ]]; then
     trap 'rm -f "${SIGNATURE_FILE}"' EXIT
     
     # Stream decode directly to file to avoid keeping data in memory
-    if ! echo "${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET}" | openssl base64 -d -A > "${SIGNATURE_FILE}"; then
+    if ! openssl base64 -d -A <<< "${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET}" > "${SIGNATURE_FILE}"; then
         rm -f "${SIGNATURE_FILE}"
         eval "${OLD_TRAP}"
         die "Failed to decode signature data"
@@ -299,7 +299,7 @@ elif [[ -v "BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET" ]]; then
 
     # Verify that the signature is valid using streaming verification
     verification_result=false
-    if echo "${BUILDKITE_INITIAL_JOB_ID}" | openssl dgst -sha256 -verify "${AGENT_PUBLIC_KEY_PATH}" -signature "${SIGNATURE_FILE}" >/dev/null 2>&1; then
+    if openssl dgst -sha256 -verify "${AGENT_PUBLIC_KEY_PATH}" -signature "${SIGNATURE_FILE}" <<< "${BUILDKITE_INITIAL_JOB_ID}" >/dev/null 2>&1; then
         verification_result=true
     fi
 

--- a/lib/yaml_extraction_prologue.sh
+++ b/lib/yaml_extraction_prologue.sh
@@ -18,7 +18,7 @@ function extract_encrypted_variables() {
             (shyaml -q keys-0 <<<"${PLUGINS}" || true) |
             while IFS='' read -r -d '' PLUGIN_NAME; do
                 # Skip plugins that are not named `cryptic`
-                if [[ "${PLUGIN_NAME}" != staticfloat/cryptic* ]]; then
+                if [[ "${PLUGIN_NAME}" != staticfloat/cryptic* ]] && [[ "${PLUGIN_NAME}" != JuliaCI/cryptic* ]]; then
                     continue
                 fi
                 # For each plugin, if its `cryptic`, extract the variables
@@ -65,7 +65,7 @@ function extract_encrypted_files() {
             (shyaml -q keys-0 <<<"${PLUGINS}" || true) |
             while IFS='' read -r -d '' PLUGIN_NAME; do
                 # Skip plugins that are not named `cryptic`
-                if [[ "${PLUGIN_NAME}" != staticfloat/cryptic* ]]; then
+                if [[ "${PLUGIN_NAME}" != staticfloat/cryptic* ]] && [[ "${PLUGIN_NAME}" != JuliaCI/cryptic* ]]; then
                     continue
                 fi
                 # For each plugin, if its `cryptic`, extract the files
@@ -76,7 +76,7 @@ function extract_encrypted_files() {
                 done
             done
         done
-    done    
+    done
 }
 
 # Calculate the treehashes of each signed pipeline defined within a launching `.yml` file,
@@ -113,7 +113,7 @@ function extract_plugin_treehashes() {
         (shyaml -q keys-0 <<<"${PLUGINS}" || true) |
         while IFS='' read -r -d '' PLUGIN_NAME; do
             # Skip plugins that are not named `cryptic`
-            if [[ "${PLUGIN_NAME}" != staticfloat/cryptic* ]]; then
+            if [[ "${PLUGIN_NAME}" != staticfloat/cryptic* ]] && [[ "${PLUGIN_NAME}" != JuliaCI/cryptic* ]]; then
                 continue
             fi
 


### PR DESCRIPTION
I asked Claude to try and figure out why things like this happen:
https://buildkite.com/julialang/julia-master/builds/49280#0198202e-d8de-4c1d-9372-49bda72fcee2
```
Running global environment hook
--
  | > C:\buildkite-agent\hooks\environment
  | -> source C:\buildkite-agent\hooks/environment.d/100_gr_env.sh
  | -> source C:\buildkite-agent\hooks/environment.d/101_julia_num_cores.sh
  | -> source C:\buildkite-agent\hooks/environment.d/110_windows_cache_drive.sh
  | -> source C:\buildkite-agent\hooks/environment.d/999_cryptic_unlock.sh
  | Showing debug information unconditionally
  | # Received cancellation signal, interrupting
  | 1 [main] bash (3136) child_copy: cygheap read copy failed, 0x18034C408..0x18036DB60, done 0, windows pid 3136, Win32 error 299
  | 437 [main] bash (3136) C:\Program Files\Git\bin\..\usr\bin\bash.exe: *** fatal error in forked process - ccalloc would have returned NULL
  | 🚨 Error: Error setting up job executor: The global environment hook exited with status 3221225786

```

And these were the top 3 suggestions.

The `BUILDKITE_PLUIGIN_CRYPYTIC_SECRETS_MOUNT_POINT` -> `BUILDKITE_PLUGIN_CRYPTIC_SECRETS_MOUNT_POINT` seems like the main issue, but Claude thought it could be a memory strain issue from the crypto stuff.. hence commit 3.